### PR TITLE
fix getAverage method to sum correctly

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,7 @@ const filterById = (id, arr) => {
 
 const getAverage = (arr, attr) => {
   let total = arr.reduce((sum, obj) => {
-    sum += obj[attr];
+    sum += parseInt(obj[attr]);
     return sum;
   }, 0);
   let average = total / arr.length;


### PR DESCRIPTION
## Summary:
The getAverage method in the utils was concatenating strings of numbers.  Added parseInt to fix this.  

## Type of Changes:
- [x] Bug fix
- [ ] Refactor
- [ ] New feature

## Where are the Changes:
utils.js

## How was this tested:
chrome dev tools

## What are the relevant tickets:
closes #67 